### PR TITLE
noopener norefferer

### DIFF
--- a/_layouts/resource.html
+++ b/_layouts/resource.html
@@ -20,7 +20,13 @@ layout: default
       <span class="text-base text-sans-sm">Agency Partners:</span>
       <span class="text-sans-sm">
         {% for partner in page.agency-partners %}
-          <a class="usa-link" href="{{ partner.href }}">{{ partner.text }}</a>
+          <a 
+            class="usa-link" 
+            href="{{ partner.href }}"
+            target="_blank"
+            rel="noopener noreferrer">
+            {{ partner.text }}
+          </a>
         {% endfor %}
       </span>
     </div>
@@ -29,7 +35,9 @@ layout: default
     <div class="mobile-lg:grid-col-6 margin-top-4 mobile-lg:margin-top-0">
       <a 
         class="usa-link site-button-link mobile-lg:float-right"
-        href="{{ page.github }}">
+        href="{{ page.github }}"
+        target="_blank"
+        rel="noopener noreferrer">
         Go to GitHub
       </a>
     </div>
@@ -44,7 +52,9 @@ layout: default
   <div class="margin-top-6">
     <a 
       class="usa-link site-button-link"
-      href="{{ page.github }}">
+      href="{{ page.github }}"
+      target="_blank"
+      rel="noopener noreferrer">
       Go to GitHub
     </a>
   </div>


### PR DESCRIPTION
Modified external links on resources pages to open in new tab with `rel=noopener noreferrer` set instead of opening without a new tab.