### PR TITLE
Move AI registry POC to uscensusbureau repo

### DIFF
--- a/_ai_models/debiasing-demographic-models.md
+++ b/_ai_models/debiasing-demographic-models.md
@@ -1,0 +1,102 @@
+---
+display-title: Bias in Demographic Models
+description: Employing explainable AI (XAI) to evaluate fairness and accountability in AI/ML models.
+layout: default
+tags:
+  - classification
+last-update: 2023-11-15
+---
+
+<h1>{{ page.display-title }}</h1>
+
+<p>
+Artificial Intelligence (AI) and Machine Learning (ML) have made tremendous advancements in recent decades. AI/ML models have been used in demographic research to gain insights for specific populations and research focuses. While these advanced models are certainly capable of providing novel and in-depth analysis, challenges related to bias and fairness remain a major issue. To address this issue of bias identification and mitigation, AI/ML models must be designed with fairness and trustworthiness as a core component of the model. Towards the fairness and trustworthiness of AI/ML models, explainable AI (XAI) has garnered interest in filling the gaps where traditional AI/ML models fall short. Explainability plays a central role in ensuring the fairness and trustworthiness of AI/ML models. In this project, we highlight the use of XAI to identify bias within AI/ML models and the datasets used for these models.
+</p>
+
+<h2>Detailed Information</h2>
+
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-open-book model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Overview</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Model name</span>: Language-Income Classification</li>
+  <li><span class="text-bold">Model author(s) and affiliations </span>(inquiries can be sent to <a href="mailto:inquiries@xd.gov">inquiries@xd.gov</a>):
+    <ul>
+      <li>Atul Rawal, Ph.D (xD - Office of Deputy Director)</li>
+      <li>Sandy L Dietrich, Ph.D (Social, Economic, and Housing Statistics Division)</li>
+      <li>James McCoy (xD - Office of Deputy Director)</li>
+    </ul>
+  </li>
+  <li><span class="text-bold">Model acquisition/development method</span>: Internally built by Atul Rawal, Sandy L Dietrich & James McCoy</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-code-brackets-square model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Anticipated Use</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Division(s)using the model</span>: xD & SEHSD</li>
+  <li><span class="text-bold">Intended application(s) and stakeholder(s) of the model</span>: Research studies for language equity in the US by xD & SEHSD</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-database-script model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Model information</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Current model version and release date</span>: V1, released on 11/3/2023</li>
+  <li><span class="text-bold">Changes made since the last release. (If any)</span>: N/A</li>
+  <li><span class="text-bold">License for use</span>: N/A </li>
+  <li><span class="text-bold">Type of model (Classification or Regression)</span>: Classification</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-network-right model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Model Architecture</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Type of algorithm used</span>: Multiple ( RF, LR, GBR, LGBM, XGB, CatBoost & CNN)</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-database model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Datasets</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Source(s) of the training data</span>: IPUMS data repository for ACS data</li>
+  <li><span class="text-bold">Data collection/ generation method</span>: Data downloaded form IPUMS for 2015 - 2019 period</li>
+  <li><span class="text-bold">Number of variables in this dataset</span>: 16</li>
+  <li><span class="text-bold">Number of entries in this dataset</span>: 500,000</li>
+  <li><span class="text-bold">Percent of data chosen as a training, testing and validation set</span>: 80% training & 20% testing</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-graph-up model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Performance Metrics</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Metrics used to rate model performance</span>:
+    <ul>
+      <li>Accuracy</li>
+      <li>Precision</li>
+      <li>Recall</li>
+      <li>F1-score</li>
+    </ul>
+  </li>
+  <li><span class="text-bold">Factors that limit the model's performance (Example: Limited dataset, Number of Nulls/NAs) (If any)</span>: N/A</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-community model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Bias</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Inclusion of information related to individuals or human populations in the training/testing/validation dataset</span>: Yes, sensitive attributes such as age, sex, race and ethnicity</li>
+  <li><span class="text-bold">Degree of risk of human judgement injecting bias within the workflow</span>: N/A</li>
+  <li><span class="text-bold">Methods used to minimize bias from human judgement</span>: N/A</li>
+  <li><span class="text-bold">Potential biases found in the training dataset from collection methods, sample size, representation, etc.</span>: Bias in sample distribution</li>
+  <li><span class="text-bold">Testing/evaluation performed to look for bias in the workflow of the model</span>: Equal distribution of the languages spoken at home</li>
+  <li><span class="text-bold">Degree of model explainability/transparency</span>: Post-hoc explainability via SHAP</li>
+</ul>
+<div class="display-flex flex-row flex-align-stretch margin-top-5">
+  <i class="iconoir-clipboard-check model-card-icon" aria-hidden="true" focusable="false"></i>
+  <h3 class="margin-0">Governance & Compliance</h3>
+</div>
+<ul>
+  <li><span class="text-bold">Model/dataset compliance with existing laws and regulations (Including privacy protection regulations)</span>: Yes, compliance with both Title 13 & 26 regulations</li>
+</ul>

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,9 @@ collections:
   resources:
     output: true
     permalink: /resources/:name/
+  ai_models:
+    output: true
+    permalink: /ai-models/:name/
 
 defaults:
   - scope:

--- a/_data/nav.yml
+++ b/_data/nav.yml
@@ -9,18 +9,20 @@ primary:
         href: /resources/mitigating-bias-in-job-postings
       - text: Model Card Generator
         href: /resources/model-card-generator
+      - text: AI Registry
+        href: /resources/ai-registry
   - text: About
     href: /about
 
 footer:
   title: Helpful Links
-  links: 
+  links:
     - text: Privacy Policy
-      href: 'https://www.census.gov/about/policies/privacy.html'
+      href: "https://www.census.gov/about/policies/privacy.html"
       isExternal: true
     - text: Accessibility
-      href: 'https://www.census.gov/about/policies/privacy/privacy-policy.html#accessibility'
+      href: "https://www.census.gov/about/policies/privacy/privacy-policy.html#accessibility"
       isExternal: true
     - text: Github
-      href: 'https://github.com/XDgov/bias-toolkit-frontend'
+      href: "https://github.com/XDgov/bias-toolkit-frontend"
       isExternal: true

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -16,6 +16,10 @@
   <link rel="stylesheet" href="{{ "/assets/uswds/css/styles.css" | relative_url }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="preload" href="{{ "/assets/uswds/js/uswds.min.js" | relative_url }}" as="script">
+  <link
+    rel="stylesheet"
+    href="https://cdn.jsdelivr.net/gh/iconoir-icons/iconoir@main/css/iconoir.css"
+  />
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-HYG1W60QS2"></script>
   <script>
     window.dataLayer = window.dataLayer || [];

--- a/_includes/model-card__container.html
+++ b/_includes/model-card__container.html
@@ -1,0 +1,38 @@
+{% assign data = include.data %}
+<div class="usa-card__container site-card__container {% if data.featured %}site-card__container--accent{% endif %}">
+  <header class="usa-card__header display-flex flex-column">
+    {% if data.featured %}
+      <h2 class="usa-card__heading font-sans-xlg">
+        {{ data.display-title }}
+      </h2>
+    {% else %}
+      <h3 class="usa-card__heading font-mono-xl">
+        {{ data.display-title }}
+      </h3>
+    {% endif %}
+    {% if data.tags %}
+      <ul class="usa-collection__meta site-card__meta {% if data.featured %}site-card__meta--accent{% endif %}" aria-label="Topics">
+        {% for tag in data.tags %}
+          <li class="usa-collection__meta-item usa-tag">{{ tag | capitalize }}</li>
+        {% endfor %}
+      </ul>
+    {% endif %}
+    {% if data.last-update %}
+      <div class="padding-y-2 font-sans-lg">
+        <span class="note-text">Last updated</span>: {{ data.last-update | date_to_string: "ordinal", "US"}}
+      </div>
+    {% endif %}
+  </header>
+  <div class="usa-card__body font-sans-lg">
+    <p>
+      {{ data.description }}
+    </p>
+  </div>
+  <div class="usa-card__footer margin-bottom-2">
+    <a
+      class="site-button-link {% if data.featured %}site-button-link--accent font-sans-md{% endif %}"
+      href="{{site.baseurl}}{{ data.url }}">
+      View Model <span class="usa-sr-only">{{data.display-title}}</span>
+    </a>
+  </div>
+</div>

--- a/_layouts/ai-model.html
+++ b/_layouts/ai-model.html
@@ -1,0 +1,16 @@
+---
+layout: default
+
+# Layout for a tool belonging to a Resource
+---
+
+<article>
+  {% if page.version %}
+    <span class="tool-version">Version {{ page.version }}</span>
+  {% endif %}
+  <header>
+    <h1 class="font-sans-3xl resource-heading">{{ page.display-title | default: page.title }}</h1>
+  </header>
+
+  {{ content }}
+</article>

--- a/_layouts/ai-registry.html
+++ b/_layouts/ai-registry.html
@@ -1,0 +1,29 @@
+---
+layout: default
+
+# Layout for a tool belonging to a Resource
+---
+
+<article>
+  {% if page.version %}
+    <span class="tool-version">Version {{ page.version }}</span>
+  {% endif %}
+  <header>
+    <h1 class="font-sans-3xl resource-heading">{{ page.display-title | default: page.title }}</h1>
+  </header>
+
+  <p>
+    The Artifical Intelligence (AI) Registry is an overview of AI and machine learning (ML) models being used at the U.S. Census Bureau. This Registry can be used to review publicly available AI projects at the Census Bureau, to provide feedback on each model, or to use each model for your own research.
+  </p>
+</article>
+<h2>All Models</h2>
+<ul class="usa-list--unstyled margin-top-1">
+  {% assign aiModels = site.ai_models %}
+  {% for model in aiModels %}
+    <li>
+      {% include model-card__container.html data=model %}
+    </li>
+  {% endfor %}
+</ul>
+
+{% include pagination.html %}

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -29,7 +29,7 @@ layout: base
   <div class="grid-container grid-row">
     <h2 class="site-topper">{{ page.resources-section.title }}</h2>
     <ul class="usa-card-group">
-      {% assign popularTools = site.resources | where_exp: "tool", "tool.featured == nil or tool.featured == false" %}
+      {% assign popularTools = site.resources | where_exp: "tool", "tool.featured == nil or tool.featured == false" | sort: "order" %}
       {% for tool in popularTools %}
         <li class="tablet:grid-col-4 usa-card site-card">
           {% include resource-card__container.html data=tool %}

--- a/_resources/ai-registry.md
+++ b/_resources/ai-registry.md
@@ -1,0 +1,13 @@
+---
+layout: ai-registry
+display-title: AI Registry
+details: An overview of the AI and Machine Learning (ML) models used by xD
+
+agency-partners:
+  - text: U.S. Census Bureau
+    href: https://www.census.gov/
+
+order: 4
+tags:
+  - website
+---

--- a/_resources/mitigating-bias-in-job-postings.md
+++ b/_resources/mitigating-bias-in-job-postings.md
@@ -7,17 +7,17 @@ agency-partners:
     href: https://www.dol.gov/
 
 github: https://github.com/USDepartmentofLabor/ableist-language-detector
-order: 4
+order: 2
 tags:
   - website
   - tool
 ---
 Ableist language is language that is offensive to people with disability. This type of language in job descriptions can cause people with disabilities to feel excluded from jobs that they are qualified for, which may result in a biased applicant pool.
 
-To address this potential source of bias, xD partnered with the U.S. Department of Labor’s Office of Disability Employment Policy (DOL ODEP) to develop a natural language processing-powered tool that will allow a user (for example: a hiring manager, human resources specialist, or a recruiter, among others) to check a job posting for ableist language. The tool identifies ableist language in the text and recommends alternative language to make the posting more inclusive for persons with disabilities. 
+To address this potential source of bias, xD partnered with the U.S. Department of Labor’s Office of Disability Employment Policy (DOL ODEP) to develop a natural language processing-powered tool that will allow a user (for example: a hiring manager, human resources specialist, or a recruiter, among others) to check a job posting for ableist language. The tool identifies ableist language in the text and recommends alternative language to make the posting more inclusive for persons with disabilities.
 
 ### Usage Instructions
-The tool is currently available as a python library, command line script, and locally-instantiated web application for those who would like to check job descriptions for ableist language. For integration into recruiting pipelines (e.g. checking job descriptions for ableist language in bulk), we recommend using the python library. For checking of individual job descriptions, we recommend using the command line script or the locally-instantiated web application, depending on if you prefer to see the results in the command line or through a graphical user interface. 
+The tool is currently available as a python library, command line script, and locally-instantiated web application for those who would like to check job descriptions for ableist language. For integration into recruiting pipelines (e.g. checking job descriptions for ableist language in bulk), we recommend using the python library. For checking of individual job descriptions, we recommend using the command line script or the locally-instantiated web application, depending on if you prefer to see the results in the command line or through a graphical user interface.
 
 For instructions on how to access and use all three versions of this tool, please see the <a href="https://github.com/USDepartmentofLabor/ableist-language-detector" target="_blank">Github repository</a>.
 
@@ -26,4 +26,4 @@ We anticipate launching a publicly-hosted version of the web application in the 
 ### Learn More
 To learn more about the methodology behind the tool, see the <a href="https://github.com/USDepartmentofLabor/ableist-language-detector" target="_blank" rel="noopener noreferrer">Github repository</a>.
 
-To learn more about our partners at DOL ODEP, see their <a href="https://www.dol.gov/agencies/odep" target="_blank" rel="noopener noreferrer">website</a>. 
+To learn more about our partners at DOL ODEP, see their <a href="https://www.dol.gov/agencies/odep" target="_blank" rel="noopener noreferrer">website</a>.

--- a/_resources/model-card-generator.md
+++ b/_resources/model-card-generator.md
@@ -7,7 +7,7 @@ agency-partners:
     href: https://www.census.gov/
 
 github: https://github.com/XDgov/model-card-generator
-order: 2
+order: 3
 tags:
   - tool
 ---

--- a/sass/_uswds-theme-custom-styles.scss
+++ b/sass/_uswds-theme-custom-styles.scss
@@ -312,3 +312,9 @@ h2 {
    display: block;
    font-size: 0.9rem;
 }
+
+.model-card-icon {
+   color: #745fe9;
+   margin-top: 4px;
+   margin-right: 6px;
+}


### PR DESCRIPTION
**note**: This PR moves https://github.com/XDgov/bias-toolkit-frontend/pull/23 to this repository to test pages.cloud.gov features.

## Description
This PR creates a rough draft of the AI Registry based on [Atul's Google Site example](https://sites.google.com/view/ai-registry) while keeping much of the Bias Toolkit styling.

The PR also includes:
* a reinstallation of node modules (consisting of the large change to `package-lock.json`) to overcome an issue where the Pages platform was failing due to missing the Linux-based Sass modules
* minor changes to have the project cards sort in the correct order

Resolves #20, #21, #22 

## Testing
* Local build testing
* Ensuring build completes on Pages (see "checks" section below)